### PR TITLE
Revert "Add workaround for postgresql charms on ARM"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,10 +45,6 @@ jobs:
           python3 -m pip install pipx
           python3 -m pipx ensurepath
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      # TODO: remove temporary workaround for postgresql charms on arm64
-      - name: (GitHub-hosted ARM runner) Install libpq-dev
-        if: ${{ matrix.runner.name == 'ARM64' }}
-        run: sudo apt-get install libpq-dev -y
       - name: Install pyenv
         run: |
           sudo apt-get update


### PR DESCRIPTION
This reverts commit 884b197e323eecbc7afc1bbe4b2bd1dd7f823242.

Depends on:
https://github.com/canonical/postgresql-operator/pull/383
https://github.com/canonical/postgresql-k8s-operator/pull/406#issuecomment-1976435914 *(if comment applied to PR; otherwise separate PR needed)
https://github.com/canonical/pgbouncer-operator/pull/175