### PR TITLE
Revert "Add canonical/data-integrator@main at path tests/integration/app-charm (#165)

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -220,11 +220,6 @@
     "relative_path_to_charmcraft_yaml": "tests/integration/application-charm"
   },
   {
-    "github_repository": "canonical/data-integrator",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "tests/integration/app-charm"
-  },
-  {
     "github_repository": "canonical/kyuubi-k8s-operator",
     "ref": "main",
     "relative_path_to_charmcraft_yaml": "tests/integration/app-charm"


### PR DESCRIPTION
This reverts commit 6f1d58b447a9255835d5ef090c7b6e9d337a9081.

The reason is that there's some bug in `build` which fails to build embedded charms that don't have `requirements.txt` (refer to Issue #170). While this PR does not solve the bug, it will unblock the caching of charms added to the list after that commit so that the cache works in the meantime while the bug is solved with a more robust solution.