### PR TITLE
Remove opensearch-dashboards-operator

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -65,11 +65,6 @@
     "relative_path_to_charmcraft_yaml": "."
   },
   {
-    "github_repository": "canonical/opensearch-dashboards-operator",
-    "ref": "2/edge",
-    "relative_path_to_charmcraft_yaml": "."
-  },
-  {
     "github_repository": "canonical/kfp-operators",
     "ref": "main",
     "relative_path_to_charmcraft_yaml": "charms/kfp-api"


### PR DESCRIPTION
Builds fail due to errors with opensearch-dashboards-operator: https://github.com/canonical/charmcraftcache-hub/actions/runs/12028137048/job/33530728252