### PR TITLE
Point notebook charms to main

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -271,12 +271,12 @@
   },
   {
     "github_repository": "canonical/notebook-operators",
-    "ref": "KF-6217-use-cache-builds-dev-branch",
+    "ref": "main",
     "relative_path_to_charmcraft_yaml": "charms/jupyter-controller"
   },
   {
     "github_repository": "canonical/notebook-operators",
-    "ref": "KF-6217-use-cache-builds-dev-branch",
+    "ref": "main",
     "relative_path_to_charmcraft_yaml": "charms/jupyter-ui"
   },
   {


### PR DESCRIPTION
Pointing to main now that https://github.com/canonical/notebook-operators/pull/426 is merged