### PR TITLE
chore: point istio charms to main

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -316,12 +316,12 @@
   },
   {
     "github_repository": "canonical/istio-operators",
-    "ref": "KF-6217-use-cache-builds-dev-branch",
+    "ref": "main",
     "relative_path_to_charmcraft_yaml": "charms/istio-gateway"
   },
   {
     "github_repository": "canonical/istio-operators",
-    "ref": "KF-6217-use-cache-builds-dev-branch",
+    "ref": "main",
     "relative_path_to_charmcraft_yaml": "charms/istio-pilot"
   },
   {


### PR DESCRIPTION
Updates the branch for istio charms due to `KF-6217-use-cache-builds-dev-branch` branch being merged to main in https://github.com/canonical/istio-operators/pull/586.