### PR TITLE
ci: drop nats-operator@main from charms.json

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -403,10 +403,5 @@
     "github_repository": "canonical/oauth2-proxy-k8s-operator",
     "ref": "ch/cache",
     "relative_path_to_charmcraft_yaml": "."
-  },
-  {
-    "github_repository": "canonical/nats-operator",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "."
   }
 ]


### PR DESCRIPTION
The charmcraftcache only supports "shorthand notation" syntax in 
charmcraft.yaml platforms while the nats-operator tracked main branch
uses the bases. This unfortunately broke the build wheel pipeline.

Hence drop nats-operator main branch from charms.json.