### PR TITLE
Revert PR #376

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -428,10 +428,5 @@
     "github_repository": "canonical/identity-platform-login-ui-operator",
     "ref": "main",
     "relative_path_to_charmcraft_yaml": "."
-  },
-  {
-    "github_repository": "canonical/wazuh-indexer-operator",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "."
   }
 ]


### PR DESCRIPTION
Remove wazuh-indexer-operator from charms.json because of broken build for the wheels and cache.

Reverts PR #376.