### PR TITLE
[DPE-6887] Update azure storage paths

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -132,12 +132,12 @@
   {
     "github_repository": "canonical/object-storage-integrators",
     "ref": "main",
-    "relative_path_to_charmcraft_yaml": "."
+    "relative_path_to_charmcraft_yaml": "azure_storage"
   },
   {
     "github_repository": "canonical/object-storage-integrators",
     "ref": "main",
-    "relative_path_to_charmcraft_yaml": "tests/integration/test-charm-azure"
+    "relative_path_to_charmcraft_yaml": "azure_storage/tests/integration/test-charm-azure"
   },
   {
     "github_repository": "canonical/mongodb-operator",


### PR DESCRIPTION
Following DA103, the azure storage integrator charm now lives under `/azure_storage`. This PR reflects this change to re enable wheel caching