### PR TITLE
Revert addition of kfp-charms

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -333,45 +333,5 @@
     "github_repository": "canonical/istio-operators",
     "ref": "KF-7310-binary-python-pkg-install",
     "relative_path_to_charmcraft_yaml": "charms/istio-pilot"
-  },
-  {
-    "github_repository": "canonical/kfp-operators",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "charms/kfp-api"
-  },
-  {
-    "github_repository": "canonical/kfp-operators",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "charms/kfp-metadata-writer"
-  },
-  {
-    "github_repository": "canonical/kfp-operators",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "charms/kfp-persistence"
-  },
-  {
-    "github_repository": "canonical/kfp-operators",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "charms/kfp-profile-controller"
-  },
-  {
-    "github_repository": "canonical/kfp-operators",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "charms/kfp-schedwf"
-  },
-  {
-    "github_repository": "canonical/kfp-operators",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "charms/kfp-ui"
-  },
-  {
-    "github_repository": "canonical/kfp-operators",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "charms/kfp-viewer"
-  },
-  {
-    "github_repository": "canonical/kfp-operators",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "charms/kfp-viz"
   }
 ]


### PR DESCRIPTION
This PR revert the additions of #412 #414 #416 #418 #420 #422 #424, and #426.

This is because `charmcraft pack` on all of them currently fails due to https://github.com/canonical/bundle-kubeflow/issues/1255.