### PR TITLE
Remove feast-integrator charm from cache

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -333,10 +333,5 @@
     "github_repository": "canonical/istio-operators",
     "ref": "KF-7310-binary-python-pkg-install",
     "relative_path_to_charmcraft_yaml": "charms/istio-pilot"
-  },
-  {
-    "github_repository": "canonical/feast-operators",
-    "ref": "main",
-    "relative_path_to_charmcraft_yaml": "charms/feast-integrator"
   }
 ]


### PR DESCRIPTION
Reverts #429 to avoid breaking the cache
Build failed in [this run](https://github.com/canonical/charmcraftcache-hub/actions/runs/14763583580), need to resolve build issue then re-add to cache