### PR TITLE
fix: point istio charms to main

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -326,12 +326,12 @@
   },
   {
     "github_repository": "canonical/istio-operators",
-    "ref": "KF-7310-binary-python-pkg-install",
+    "ref": "main",
     "relative_path_to_charmcraft_yaml": "charms/istio-gateway"
   },
   {
     "github_repository": "canonical/istio-operators",
-    "ref": "KF-7310-binary-python-pkg-install",
+    "ref": "main",
     "relative_path_to_charmcraft_yaml": "charms/istio-pilot"
   },
   {


### PR DESCRIPTION
update istio charms  ref branch to main due to https://github.com/canonical/istio-operators/pull/618 being merged 