### PR TITLE
chore: Add `k8s-operator` back

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -478,5 +478,15 @@
     "github_repository": "canonical/self-signed-certificates-operator",
     "ref": "main",
     "relative_path_to_charmcraft_yaml": "."
+  },
+  {
+    "github_repository": "canonical/k8s-operator",
+    "ref": "main",
+    "relative_path_to_charmcraft_yaml": "charms/worker/k8s"
+  },
+  {
+    "github_repository": "canonical/k8s-operator",
+    "ref": "main",
+    "relative_path_to_charmcraft_yaml": "charms/worker"
   }
 ]


### PR DESCRIPTION
## Overview
`k8s-operator` charms now support the shorthand notion, adding them back to the list of supported charms.