### PR TITLE
Update ref branches for charmed-spark charms

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -96,17 +96,17 @@
   },
   {
     "github_repository": "canonical/spark-history-server-k8s-operator",
-    "ref": "main",
+    "ref": "3/edge",
     "relative_path_to_charmcraft_yaml": "."
   },
   {
     "github_repository": "canonical/spark-integration-hub-k8s-operator",
-    "ref": "main",
+    "ref": "3/edge",
     "relative_path_to_charmcraft_yaml": "."
   },
   {
     "github_repository": "canonical/spark-integration-hub-k8s-operator",
-    "ref": "main",
+    "ref": "3/edge",
     "relative_path_to_charmcraft_yaml": "tests/integration/app-charm"
   },
   {
@@ -181,7 +181,7 @@
   },
   {
     "github_repository": "canonical/kyuubi-k8s-operator",
-    "ref": "main",
+    "ref": "3.5/edge",
     "relative_path_to_charmcraft_yaml": "."
   },
   {


### PR DESCRIPTION
This PR updates the default branches for Charmed Spark products, as we don't merge anything into main anymore