### PR TITLE
patch: Add 2/edge opensearch + dashboards charms

### DIFF
--- a/charms.json
+++ b/charms.json
@@ -637,12 +637,12 @@
   {
     "github_repository": "canonical/opensearch-dashboards-single-kernel-library",
     "ref": "2/edge",
-    "relative_path_to_charmcraft_yaml": "tests/charms/dashboards_k8s_charm"
+    "relative_path_to_charmcraft_yaml": "tests/charms/dashboards_charm"
   },
   {
     "github_repository": "canonical/opensearch-dashboards-single-kernel-library",
     "ref": "2/edge",
-    "relative_path_to_charmcraft_yaml": "tests/charms/dashboards_vm_charm"
+    "relative_path_to_charmcraft_yaml": "tests/integration/dashboards_k8s_upgrade_test_charm"
   },
   {
     "github_repository": "canonical/mongo-single-kernel-library",

--- a/charms.json
+++ b/charms.json
@@ -645,12 +645,12 @@
     "relative_path_to_charmcraft_yaml": "tests/integration/dashboards_k8s_upgrade_test_charm"
   },
   {
-    "github_repository": "canonical/mongo-single-kernel-library",
+    "github_repository": "opensearch-dashboards-single-kernel-library",
     "ref": "2/edge",
     "relative_path_to_charmcraft_yaml": "tests/integration/dashboards_application_charm"
   },
   {
-    "github_repository": "canonical/mongo-single-kernel-library",
+    "github_repository": "opensearch-dashboards-single-kernel-library",
     "ref": "2/edge",
     "relative_path_to_charmcraft_yaml": "tests/integration/dashboards_tester_charm"
   },

--- a/charms.json
+++ b/charms.json
@@ -135,16 +135,6 @@
     "relative_path_to_charmcraft_yaml": "."
   },
   {
-    "github_repository": "canonical/opensearch-dashboards-operator",
-    "ref": "2/edge",
-    "relative_path_to_charmcraft_yaml": "."
-  },
-  {
-    "github_repository": "canonical/opensearch-dashboards-operator",
-    "ref": "2/edge",
-    "relative_path_to_charmcraft_yaml": "tests/integration/application-charm"
-  },
-  {
     "github_repository": "canonical/s3-integrator",
     "ref": "main",
     "relative_path_to_charmcraft_yaml": "."
@@ -618,6 +608,51 @@
     "github_repository": "canonical/opensearch-operator",
     "ref": "2/edge",
     "relative_path_to_charmcraft_yaml": "."
+  },
+  {
+    "github_repository": "canonical/opensearch-single-kernel-library",
+    "ref": "2/edge",
+    "relative_path_to_charmcraft_yaml": "tests/charms/dummy-client-charm"
+  },
+  {
+    "github_repository": "canonical/opensearch-single-kernel-library",
+    "ref": "2/edge",
+    "relative_path_to_charmcraft_yaml": "tests/charms/opensearch_k8s_2.19.4_test_charm"
+  },
+  {
+    "github_repository": "canonical/opensearch-single-kernel-library",
+    "ref": "2/edge",
+    "relative_path_to_charmcraft_yaml": "tests/charms/opensearch_k8s_test_charm"
+  },
+  {
+    "github_repository": "canonical/opensearch-single-kernel-library",
+    "ref": "2/edge",
+    "relative_path_to_charmcraft_yaml": "tests/charms/opensearch_test_charm"
+  },
+  {
+    "github_repository": "canonical/opensearch-dashboards-operator",
+    "ref": "2/edge",
+    "relative_path_to_charmcraft_yaml": "."
+  },
+  {
+    "github_repository": "canonical/opensearch-dashboards-single-kernel-library",
+    "ref": "2/edge",
+    "relative_path_to_charmcraft_yaml": "tests/charms/dashboards_k8s_charm"
+  },
+  {
+    "github_repository": "canonical/opensearch-dashboards-single-kernel-library",
+    "ref": "2/edge",
+    "relative_path_to_charmcraft_yaml": "tests/charms/dashboards_vm_charm"
+  },
+  {
+    "github_repository": "canonical/mongo-single-kernel-library",
+    "ref": "2/edge",
+    "relative_path_to_charmcraft_yaml": "tests/integration/dashboards_application_charm"
+  },
+  {
+    "github_repository": "canonical/mongo-single-kernel-library",
+    "ref": "2/edge",
+    "relative_path_to_charmcraft_yaml": "tests/integration/dashboards_tester_charm"
   },
   {
     "github_repository": "canonical/velero-operator",

--- a/charms.json
+++ b/charms.json
@@ -645,12 +645,12 @@
     "relative_path_to_charmcraft_yaml": "tests/integration/dashboards_k8s_upgrade_test_charm"
   },
   {
-    "github_repository": "opensearch-dashboards-single-kernel-library",
+    "github_repository": "canonical/opensearch-dashboards-single-kernel-library",
     "ref": "2/edge",
     "relative_path_to_charmcraft_yaml": "tests/integration/dashboards_application_charm"
   },
   {
-    "github_repository": "opensearch-dashboards-single-kernel-library",
+    "github_repository": "canonical/opensearch-dashboards-single-kernel-library",
     "ref": "2/edge",
     "relative_path_to_charmcraft_yaml": "tests/integration/dashboards_tester_charm"
   },


### PR DESCRIPTION
This PR adds opensearch+dashboards test VM+k8s charms 